### PR TITLE
Allow hyper client to make http connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcp_auth"
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/hrvolapeter/gcp_auth"
 description = "Google cloud platform (GCP) authentication using default and custom service accounts"
 documentation = "https://docs.rs/gcp_auth/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rustls = "0.20.2"
 rustls-pemfile = "0.2.1"
 serde = {version = "1.0", features = ["derive", "rc"]}
 serde_json = "1.0"
-tokio = { version = "1.1", features = ["fs"] }
+tokio = { version = "1.1", features = ["fs", "sync"] }
 url = "2"
 which = "4.2"
 async-trait = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ async fn get_authentication_manager(
     let https = HttpsConnectorBuilder::new().with_native_roots();
 
     let client =
-        Client::builder().build::<_, hyper::Body>(https.https_only().enable_http2().build());
+        Client::builder().build::<_, hyper::Body>(https.https_or_http().enable_http2().build());
 
     let custom = match credential_path {
         Some(path) => CustomServiceAccount::from_file(path).await,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,31 +111,28 @@ async fn get_authentication_manager(
     };
 
     if let Ok(service_account) = custom {
-        return Ok(AuthenticationManager {
+        return Ok(AuthenticationManager::new(
             client,
-            service_account: Box::new(service_account),
-        });
+            Box::new(service_account),
+        ));
     }
     let gcloud = gcloud_authorized_user::GCloudAuthorizedUser::new().await;
     if let Ok(service_account) = gcloud {
-        return Ok(AuthenticationManager {
-            client: client.clone(),
-            service_account: Box::new(service_account),
-        });
+        return Ok(AuthenticationManager::new(
+            client.clone(),
+            Box::new(service_account),
+        ));
     }
     let default = default_service_account::DefaultServiceAccount::new(&client).await;
     if let Ok(service_account) = default {
-        return Ok(AuthenticationManager {
-            client: client.clone(),
-            service_account: Box::new(service_account),
-        });
+        return Ok(AuthenticationManager::new(
+            client.clone(),
+            Box::new(service_account),
+        ));
     }
     let user = default_authorized_user::DefaultAuthorizedUser::new(&client).await;
     if let Ok(user_account) = user {
-        return Ok(AuthenticationManager {
-            client,
-            service_account: Box::new(user_account),
-        });
+        return Ok(AuthenticationManager::new(client, Box::new(user_account)));
     }
     Err(Error::NoAuthMethod(
         Box::new(custom.unwrap_err()),


### PR DESCRIPTION
When using the DefaultServiceAccount the request is over http, using
https there is not supported.  Since all the used URLs are hardcoded
there is no risk of accidentally not using https when needed.